### PR TITLE
Teamwork Quests - era change to a full 6 paty members on each quest

### DIFF
--- a/raw_data/dialog/West_Ronfaure.yml
+++ b/raw_data/dialog/West_Ronfaure.yml
@@ -18226,7 +18226,7 @@ entries:
   7490: Excellent! Well done! I believe you've learned the value of teamwork.${prompt}
   7491: You may not measure up to my elite squad here, but keep at it, and someday, maybe you'll win a post here in the watchtower.${prompt}
   7492: I give you this to commemorate your achievement, and the strength of your party. May you and your comrades-in-arms grow in strength, and prosper.${prompt}
-  7493: Hmm...you seem to be short of members. You need more people than just yourself. Bring them here once you've gathered them.${prompt}
+  7493: Hmm...you seem to be short of members. Bring them here once you've gathered them.${prompt}
   7494: Not all of your members are of the same nationality!${prompt}
   7495: Not all of your members are of the same race!${prompt}
   7496: Not all of your members have the same job!${prompt}


### PR DESCRIPTION
currently set to at least 2 players but in era needed a full party of 6 to complete.
game files already reflect this but have system messages in place to tell people to get 6 instead of 2 people