### PR TITLE
Correcting INT bonus on Crimson Jelly

### DIFF
--- a/raw_data/items/usable_items.yml
+++ b/raw_data/items/usable_items.yml
@@ -27253,7 +27253,7 @@ items:
     description: |-
       The detoxified gelatinous remains of a
       clot, whipped up into a tasty dessert.
-      MP+12% (Max. 85) INT-6
+      MP+12% (Max. 85) INT+6
       MP recovered while healing +2
   flags:
   - MysteryBox


### PR DESCRIPTION
Changed the INT bonus on Crimson Jelly from -6 to +6 so that tooltip matches the effect